### PR TITLE
백엔드 개인 도메인 전체조회, 조회 권한문제 수정

### DIFF
--- a/src/main/java/com/command/toyvillage_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/command/toyvillage_server/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -52,7 +53,17 @@ public class SecurityConfig {
                 .sessionManagement(sessionManagement -> sessionManagement
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        // auth
                         .requestMatchers("/auth/login", "/auth/signup", "/auth/password", "/auth/password/verification", "/auth/password/verification/confirm").permitAll()
+                        .requestMatchers("/auth/reissue").authenticated()
+
+                        // animal
+                        .requestMatchers(HttpMethod.GET, "/animal", "/animal/**").permitAll()
+                        .requestMatchers("/animal", "/animal/**").authenticated()
+
+                        // popup
+                        .requestMatchers(HttpMethod.GET, "/popup", "/popup/**").permitAll()
+                        .requestMatchers("/popup", "/popup/**").authenticated()
                         .anyRequest().authenticated()
                 )
                 .with(new SecurityFilterConfig(jwtTokenProvider, objectMapper), Customizer.withDefaults())


### PR DESCRIPTION
### **📝 작업 내용**

- 백엔드 개인 도메인 전체조회, 조회 권한문제 수정

### **⚠ 수정 사항 (기존 코드 변경 시)**

- 수정 이유 및 변경 내용

### **✅ 테스트 결과**

- 정상 동작 확인
- 예외 테스트 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 동물 및 팝업 관련 리소스에 대한 접근 권한을 재구성했습니다. 조회 요청은 모든 사용자에게 허용되며, 그 외 작업(생성, 수정, 삭제)은 인증된 사용자만 수행할 수 있도록 제한되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToyVillage/ToyVillage-WebSite-BE/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->