### PR TITLE
Fix/55 gallery 조회, file 업로드, faq 조회 권한문제 수정

### DIFF
--- a/src/main/java/com/command/toyvillage_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/command/toyvillage_server/global/config/SecurityConfig.java
@@ -54,9 +54,14 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/auth/login", "/auth/signup", "/auth/password", "/auth/password/verification", "/auth/password/verification/confirm").permitAll()
+                    // faq
                     .requestMatchers(HttpMethod.GET, "/faq").permitAll()
                     .requestMatchers(HttpMethod.GET, "/faq/{id}").permitAll()
+
+                    // file
                     .requestMatchers(HttpMethod.POST, "/file").permitAll()
+
+                    // gallery
                     .requestMatchers(HttpMethod.GET, "/gallery").permitAll()
                     .requestMatchers(HttpMethod.GET, "/gallery/{id}").permitAll()
                     .anyRequest().authenticated()

--- a/src/main/java/com/command/toyvillage_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/command/toyvillage_server/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -52,8 +53,13 @@ public class SecurityConfig {
                 .sessionManagement(sessionManagement -> sessionManagement
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/login", "/auth/signup", "/auth/password", "/auth/password/verification", "/auth/password/verification/confirm").permitAll()
-                        .anyRequest().authenticated()
+                    .requestMatchers("/auth/login", "/auth/signup", "/auth/password", "/auth/password/verification", "/auth/password/verification/confirm").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/faq").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/faq/{id}").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/file").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/gallery").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/gallery/{id}").permitAll()
+                    .anyRequest().authenticated()
                 )
                 .with(new SecurityFilterConfig(jwtTokenProvider, objectMapper), Customizer.withDefaults())
                 .build();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **관련 이슈**
  * resolved #55

* **보안 정책 변경**
  * FAQ 조회(GET /faq, GET /faq/{id}), 갤러리 조회(GET /gallery, GET /gallery/{id}) 및 파일 업로드(POST /file)에 대해 로그인 없이 접근할 수 있도록 변경되었습니다.
  * 그 외 엔드포인트는 기존처럼 인증이 필요합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ToyVillage/ToyVillage-WebSite-BE/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->