### PR TITLE
Feature/72 notice update get

### DIFF
--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/domain/Notice.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/domain/Notice.java
@@ -26,4 +26,10 @@ public class Notice {
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
+
+    public void update(String title, Kind kind, String content) {
+        this.title = title;
+        this.kind = kind;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/domain/Notice.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/domain/Notice.java
@@ -2,7 +2,8 @@ package com.command.toyvillage_server.domain.app.notice.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import java.time.LocalDateTime;
+
+import java.time.LocalDate;
 
 @Getter
 @Builder
@@ -25,7 +26,7 @@ public class Notice {
     private String content;
 
     @Column(nullable = false)
-    private LocalDateTime createdAt;
+    private LocalDate createdAt;
 
     public void update(String title, Kind kind, String content) {
         this.title = title;

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/exception/NoticeNotFoundException.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/exception/NoticeNotFoundException.java
@@ -1,11 +1,12 @@
 package com.command.toyvillage_server.domain.app.notice.exception;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
+import com.command.toyvillage_server.global.error.exception.ErrorCode;
+import com.command.toyvillage_server.global.error.exception.ToyVillageException;
 
-public class NoticeNotFoundException extends ResponseStatusException {
+public class NoticeNotFoundException extends ToyVillageException {
+    public static final ToyVillageException EXCEPTION = new NoticeNotFoundException();
 
-    public NoticeNotFoundException(Long noticeId) {
-        super(HttpStatus.NOT_FOUND, "공지사항을 찾을 수 없습니다. id=" + noticeId);
+    public NoticeNotFoundException() {
+        super(ErrorCode.NOTICE_NOT_FOUND);
     }
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/NoticeController.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/NoticeController.java
@@ -1,21 +1,38 @@
 package com.command.toyvillage_server.domain.app.notice.presentation;
 
+import com.command.toyvillage_server.domain.app.notice.presentation.dto.request.NoticeRequestDto;
+import com.command.toyvillage_server.domain.app.notice.presentation.dto.response.NoticeResponseDto;
 import com.command.toyvillage_server.domain.app.notice.service.NoticeDeleteService;
+import com.command.toyvillage_server.domain.app.notice.service.NoticeUpdateService;
+import com.command.toyvillage_server.domain.app.notice.service.QueryNoticeDetailService;
+import com.command.toyvillage_server.domain.app.notice.service.QueryNoticeListService;
 import com.command.toyvillage_server.global.common.response.MessageResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/notice")
 public class NoticeController {
+    private final QueryNoticeDetailService queryNoticeDetailService;
+    private final QueryNoticeListService queryNoticeListService;
+    private final NoticeUpdateService noticeUpdateService;
     private final NoticeDeleteService noticeDeleteService;
+
+    @PutMapping("/{noticeId}")
+    @ResponseStatus(HttpStatus.OK)
+    public MessageResponse update(@Valid @RequestBody NoticeRequestDto request, @PathVariable Long noticeId) {
+        noticeUpdateService.execute(noticeId, request);
+        return MessageResponse.of("공지 수정 성공");
+    }
+
 
     @DeleteMapping("/{noticeId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/NoticeController.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/NoticeController.java
@@ -33,6 +33,12 @@ public class NoticeController {
         return MessageResponse.of("공지 수정 성공");
     }
 
+    @GetMapping("/{noticeId}")
+    @ResponseStatus(HttpStatus.OK)
+    public NoticeResponseDto getDetail(@PathVariable Long noticeId) {
+        return queryNoticeDetailService.execute(noticeId);
+    }
+
 
     @DeleteMapping("/{noticeId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/NoticeController.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/NoticeController.java
@@ -39,6 +39,11 @@ public class NoticeController {
         return queryNoticeDetailService.execute(noticeId);
     }
 
+    @GetMapping
+    public List<NoticeResponseDto> getList(@PageableDefault(page = 0, size = 10) Pageable pageable) {
+        return queryNoticeListService.execute(pageable);
+    }
+
 
     @DeleteMapping("/{noticeId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/dto/request/NoticeRequestDto.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/dto/request/NoticeRequestDto.java
@@ -1,0 +1,18 @@
+package com.command.toyvillage_server.domain.app.notice.presentation.dto.request;
+
+import com.command.toyvillage_server.domain.app.notice.domain.Kind;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class NoticeRequestDto {
+    @NotBlank
+    private String title;
+
+    @NotNull
+    private Kind kind;
+
+    @NotBlank
+    private String content;
+}

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/dto/response/NoticeResponseDto.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/dto/response/NoticeResponseDto.java
@@ -4,7 +4,7 @@ import com.command.toyvillage_server.domain.app.notice.domain.Kind;
 import com.command.toyvillage_server.domain.app.notice.domain.Notice;
 import lombok.Builder;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Builder
 public record NoticeResponseDto(
@@ -12,7 +12,7 @@ public record NoticeResponseDto(
     String title,
     Kind kind,
     String content,
-    LocalDateTime createdAt
+    LocalDate createdAt
 ) {
     public static NoticeResponseDto from(Notice notice) {
         return NoticeResponseDto.builder()

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/dto/response/NoticeResponseDto.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/dto/response/NoticeResponseDto.java
@@ -1,0 +1,26 @@
+package com.command.toyvillage_server.domain.app.notice.presentation.dto.response;
+
+import com.command.toyvillage_server.domain.app.notice.domain.Kind;
+import com.command.toyvillage_server.domain.app.notice.domain.Notice;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record NoticeResponseDto(
+    Long id,
+    String title,
+    Kind kind,
+    String content,
+    LocalDateTime createdAt
+) {
+    public static NoticeResponseDto from(Notice notice) {
+        return NoticeResponseDto.builder()
+            .id(notice.getId())
+            .title(notice.getTitle())
+            .kind(notice.getKind())
+            .content(notice.getContent())
+            .createdAt(notice.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/service/NoticeDeleteService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/service/NoticeDeleteService.java
@@ -16,7 +16,7 @@ public class NoticeDeleteService {
     @Transactional
     public void execute(Long noticeId) {
         Notice notice = noticeRepository.findById(noticeId)
-                .orElseThrow(() -> new NoticeNotFoundException(noticeId));
+                .orElseThrow(() -> NoticeNotFoundException.EXCEPTION);
         noticeRepository.delete(notice);
     }
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/service/NoticeUpdateService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/service/NoticeUpdateService.java
@@ -1,0 +1,24 @@
+package com.command.toyvillage_server.domain.app.notice.service;
+
+import com.command.toyvillage_server.domain.app.notice.domain.Notice;
+import com.command.toyvillage_server.domain.app.notice.domain.repository.NoticeRepository;
+import com.command.toyvillage_server.domain.app.notice.exception.NoticeNotFoundException;
+import com.command.toyvillage_server.domain.app.notice.presentation.dto.request.NoticeRequestDto;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class NoticeUpdateService {
+    private final NoticeRepository noticeRepository;
+
+    @Transactional
+    public void execute(Long id, NoticeRequestDto dto) {
+        Notice notice = noticeRepository.findById(id)
+            .orElseThrow(() -> NoticeNotFoundException.EXCEPTION);
+
+        notice.update(dto.getTitle(), dto.getKind(), dto.getContent());
+        noticeRepository.save(notice);
+    }
+}

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/service/QueryNoticeDetailService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/service/QueryNoticeDetailService.java
@@ -1,0 +1,23 @@
+package com.command.toyvillage_server.domain.app.notice.service;
+
+import com.command.toyvillage_server.domain.app.notice.domain.Notice;
+import com.command.toyvillage_server.domain.app.notice.domain.repository.NoticeRepository;
+import com.command.toyvillage_server.domain.app.notice.exception.NoticeNotFoundException;
+import com.command.toyvillage_server.domain.app.notice.presentation.dto.response.NoticeResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class QueryNoticeDetailService {
+    private final NoticeRepository noticeRepository;
+
+    @Transactional(readOnly = true)
+    public NoticeResponseDto execute(Long id) {
+        Notice notice = noticeRepository.findById(id)
+            .orElseThrow(() -> NoticeNotFoundException.EXCEPTION);
+
+        return NoticeResponseDto.from(notice);
+    }
+}

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/service/QueryNoticeListService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/service/QueryNoticeListService.java
@@ -1,0 +1,31 @@
+package com.command.toyvillage_server.domain.app.notice.service;
+
+import com.command.toyvillage_server.domain.app.notice.domain.repository.NoticeRepository;
+import com.command.toyvillage_server.domain.app.notice.presentation.dto.response.NoticeResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class QueryNoticeListService {
+    private final NoticeRepository noticeRepository;
+
+    @Transactional(readOnly = true)
+    public List<NoticeResponseDto> execute(Pageable p) {
+        Pageable pageable = PageRequest.of(
+            p.getPageNumber(),
+            p.getPageSize(),
+            Sort.by(Sort.Direction.DESC, "id")
+        );
+
+        return noticeRepository.findAll(pageable)
+            .map(NoticeResponseDto::from)
+            .toList();
+    }
+}

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/service/QueryNoticeListService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/service/QueryNoticeListService.java
@@ -21,7 +21,7 @@ public class QueryNoticeListService {
         Pageable pageable = PageRequest.of(
             p.getPageNumber(),
             p.getPageSize(),
-            Sort.by(Sort.Direction.DESC, "id")
+            p.getSortOr(Sort.by(Sort.Direction.DESC, "id"))
         );
 
         return noticeRepository.findAll(pageable)

--- a/src/main/java/com/command/toyvillage_server/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/command/toyvillage_server/global/error/exception/ErrorCode.java
@@ -60,8 +60,10 @@ public enum ErrorCode {
     FILE_NOT_FOUND(404, "파일을 찾을 수 없습니다."),
 
     //gallery
-    GALLERY_NOT_FOUND(404, "존재하지 않는 갤러리입니다.");
+    GALLERY_NOT_FOUND(404, "존재하지 않는 갤러리입니다."),
 
+    //notice
+    NOTICE_NOT_FOUND(404, "존재하지 않는 공지사항입니다.");
     private final int statusCode;
     private final String errorMessage;
 }


### PR DESCRIPTION
### 변경 사항
- notice 수정, 조회 구현
- exception 싱글톤으로 변경
- update 메서드 추가

### 관련 이슈
resolved #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 공지 상세 조회(`GET /notice/{noticeId}`) 및 목록 조회(`GET /notice`, 페이징 지원), 수정(`PUT /notice/{noticeId}`) API가 추가되었습니다.
  * 공지 요청/응답 형식이 정리되었으며, 응답에는 공지 생성일(`createdAt`)이 날짜 기준으로 제공됩니다.
* **버그 수정**
  * 존재하지 않는 공지에 대한 오류 응답이 더 일관되게 처리되며, 공지 전용 오류 코드가 추가되었습니다.
* **변경 사항**
  * 공지 생성(`POST`)과 삭제(`DELETE`) 기능은 더 이상 지원되지 않습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->