### PR TITLE
feat : opentime에 날짜 추가

### DIFF
--- a/src/main/java/com/command/toyvillage_server/domain/app/open_time/domain/OpenTime.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/open_time/domain/OpenTime.java
@@ -5,6 +5,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Getter
@@ -16,6 +18,9 @@ public class OpenTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "open_date", nullable = false)
+    private LocalDate openDate;
+
     @Column(name = "start_open_time", nullable = false)
     private LocalTime startOpenTime;
 
@@ -23,19 +28,22 @@ public class OpenTime {
     private LocalTime endOpenTime;
 
     @Builder
-    private OpenTime(LocalTime startOpenTime, LocalTime endOpenTime) {
+    private OpenTime(LocalDate openDate, LocalTime startOpenTime, LocalTime endOpenTime) {
+        this.openDate = openDate;
         this.startOpenTime = startOpenTime;
         this.endOpenTime = endOpenTime;
     }
 
-    public static OpenTime create(LocalTime startOpenTime, LocalTime endOpenTime) {
+    public static OpenTime create(LocalDate openDate, LocalTime startOpenTime, LocalTime endOpenTime) {
         return OpenTime.builder()
+                .openDate(openDate)
                 .startOpenTime(startOpenTime)
                 .endOpenTime(endOpenTime)
                 .build();
     }
 
-    public void update(LocalTime startOpenTime, LocalTime endOpenTime) {
+    public void update(LocalDate openDate, LocalTime startOpenTime, LocalTime endOpenTime) {
+        this.openDate = openDate;
         this.startOpenTime = startOpenTime;
         this.endOpenTime = endOpenTime;
     }

--- a/src/main/java/com/command/toyvillage_server/domain/app/open_time/domain/repository/OpenTimeRepository.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/open_time/domain/repository/OpenTimeRepository.java
@@ -3,8 +3,11 @@ package com.command.toyvillage_server.domain.app.open_time.domain.repository;
 import com.command.toyvillage_server.domain.app.open_time.domain.OpenTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface OpenTimeRepository extends JpaRepository<OpenTime, Long> {
-    List<OpenTime> findAllByOrderByIdAsc();
+    List<OpenTime> findAllByOrderByOpenDateAscStartOpenTimeAscIdAsc();
+
+    List<OpenTime> findAllByOpenDateOrderByStartOpenTimeAscIdAsc(LocalDate openDate);
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/open_time/presentation/OpenTimeController.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/open_time/presentation/OpenTimeController.java
@@ -5,11 +5,13 @@ import com.command.toyvillage_server.domain.app.open_time.presentation.dto.respo
 import com.command.toyvillage_server.domain.app.open_time.service.OpenTimeCreateService;
 import com.command.toyvillage_server.domain.app.open_time.service.OpenTimeDeleteService;
 import com.command.toyvillage_server.domain.app.open_time.service.OpenTimeUpdateService;
+import com.command.toyvillage_server.domain.app.open_time.service.QueryOpenTimeByDateService;
 import com.command.toyvillage_server.domain.app.open_time.service.QueryOpenTimeDetailService;
 import com.command.toyvillage_server.domain.app.open_time.service.QueryOpenTimeListService;
 import com.command.toyvillage_server.global.common.response.MessageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -19,8 +21,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -31,6 +35,7 @@ public class OpenTimeController {
     private final OpenTimeUpdateService openTimeUpdateService;
     private final OpenTimeDeleteService openTimeDeleteService;
     private final QueryOpenTimeListService queryOpenTimeListService;
+    private final QueryOpenTimeByDateService queryOpenTimeByDateService;
     private final QueryOpenTimeDetailService queryOpenTimeDetailService;
 
     @PostMapping
@@ -66,6 +71,13 @@ public class OpenTimeController {
     @GetMapping
     public List<OpenTimeResponse> getOpenTimes() {
         return queryOpenTimeListService.execute();
+    }
+
+    @GetMapping("/date")
+    public List<OpenTimeResponse> getOpenTimesByDate(
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        return queryOpenTimeByDateService.execute(date);
     }
 
     @GetMapping("/{open-time-id}")

--- a/src/main/java/com/command/toyvillage_server/domain/app/open_time/presentation/dto/request/OpenTimeRequest.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/open_time/presentation/dto/request/OpenTimeRequest.java
@@ -2,9 +2,13 @@ package com.command.toyvillage_server.domain.app.open_time.presentation.dto.requ
 
 import jakarta.validation.constraints.NotNull;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 public record OpenTimeRequest(
+        @NotNull(message = "운영 날짜를 입력해주세요.")
+        LocalDate openDate,
+
         @NotNull(message = "운영 시작시간을 입력해주세요.")
         LocalTime startOpenTime,
 

--- a/src/main/java/com/command/toyvillage_server/domain/app/open_time/presentation/dto/response/OpenTimeResponse.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/open_time/presentation/dto/response/OpenTimeResponse.java
@@ -3,17 +3,20 @@ package com.command.toyvillage_server.domain.app.open_time.presentation.dto.resp
 import com.command.toyvillage_server.domain.app.open_time.domain.OpenTime;
 import lombok.Builder;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Builder
 public record OpenTimeResponse(
         Long id,
+        LocalDate openDate,
         LocalTime startOpenTime,
         LocalTime endOpenTime
 ) {
     public static OpenTimeResponse from(OpenTime openTime) {
         return OpenTimeResponse.builder()
                 .id(openTime.getId())
+                .openDate(openTime.getOpenDate())
                 .startOpenTime(openTime.getStartOpenTime())
                 .endOpenTime(openTime.getEndOpenTime())
                 .build();

--- a/src/main/java/com/command/toyvillage_server/domain/app/open_time/service/OpenTimeCreateService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/open_time/service/OpenTimeCreateService.java
@@ -17,6 +17,7 @@ public class OpenTimeCreateService {
         OpenTimePeriodValidator.validate(request.startOpenTime(), request.endOpenTime());
 
         OpenTime openTime = OpenTime.create(
+                request.openDate(),
                 request.startOpenTime(),
                 request.endOpenTime()
         );

--- a/src/main/java/com/command/toyvillage_server/domain/app/open_time/service/OpenTimeUpdateService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/open_time/service/OpenTimeUpdateService.java
@@ -21,6 +21,7 @@ public class OpenTimeUpdateService {
                 .orElseThrow(() -> OpenTimeNotFoundException.EXCEPTION);
 
         openTime.update(
+                request.openDate(),
                 request.startOpenTime(),
                 request.endOpenTime()
         );

--- a/src/main/java/com/command/toyvillage_server/domain/app/open_time/service/QueryOpenTimeByDateService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/open_time/service/QueryOpenTimeByDateService.java
@@ -6,16 +6,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class QueryOpenTimeListService {
+public class QueryOpenTimeByDateService {
     private final OpenTimeRepository openTimeRepository;
 
     @Transactional(readOnly = true)
-    public List<OpenTimeResponse> execute() {
-        return openTimeRepository.findAllByOrderByOpenDateAscStartOpenTimeAscIdAsc()
+    public List<OpenTimeResponse> execute(LocalDate date) {
+        return openTimeRepository.findAllByOpenDateOrderByStartOpenTimeAscIdAsc(date)
                 .stream()
                 .map(OpenTimeResponse::from)
                 .toList();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 운영 시간에 날짜 정보를 등록하고 수정할 수 있습니다.
  * 특정 날짜의 운영 시간을 조회하는 기능을 추가했습니다.
  * 운영 시간 조회 결과에 운영 날짜가 포함됩니다.

* **개선**
  * 전체 운영 시간이 날짜, 시작 시간 순으로 정렬되어 표시됩니다.
  * 날짜별 운영 시간은 시작 시간 순으로 정렬됩니다.
  * 운영 날짜 입력값은 필수 항목으로 검증됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->