### PR TITLE
Feature/92 notice에 file 연결

### DIFF
--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/domain/Notice.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/domain/Notice.java
@@ -1,9 +1,12 @@
 package com.command.toyvillage_server.domain.app.notice.domain;
 
+import com.command.toyvillage_server.domain.web.file.domain.File;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,20 +31,31 @@ public class Notice {
     @Column(nullable = false)
     private LocalDate createdAt;
 
-    public void update(String title, Kind kind, String content) {
+    @OneToMany
+    @JoinTable(
+        name = "tbl_notice_file",
+        joinColumns = @JoinColumn(name = "notice_id", nullable = false),
+        inverseJoinColumns = @JoinColumn(name = "file_id", unique = true, nullable = false)
+    )
+    private List<File> files = new ArrayList<>();
+
+    public void update(String title, Kind kind, String content, List<File> files) {
         this.title = title;
         this.kind = kind;
         this.content = content;
+        this.files.clear();
+        this.files.addAll(files);
     }
 
-    private Notice(String title, Kind kind, String content) {
+    private Notice(String title, Kind kind, String content,  List<File> files) {
         this.title = title;
         this.kind = kind;
         this.content = content;
         this.createdAt = LocalDate.now();
+        this.files = new ArrayList<>(files);
     }
 
-    public static Notice create(String title, Kind kind, String content) {
-        return new Notice(title, kind, content);
+    public static Notice create(String title, Kind kind, String content,  List<File> files) {
+        return new Notice(title, kind, content,  files);
     }
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/domain/Notice.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/domain/Notice.java
@@ -43,8 +43,10 @@ public class Notice {
         this.title = title;
         this.kind = kind;
         this.content = content;
-        this.files.clear();
-        this.files.addAll(files);
+        if (files != null) {
+            this.files.clear();
+            this.files.addAll(files);
+        }
     }
 
     private Notice(String title, Kind kind, String content,  List<File> files) {

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/NoticeController.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/NoticeController.java
@@ -29,16 +29,16 @@ public class NoticeController {
     private final NoticeDeleteService noticeDeleteService;
     private final NoticeCreateService noticeCreateService;
 
-    @PutMapping("/{noticeId}")
+    @PutMapping("/{notice-id}")
     @ResponseStatus(HttpStatus.OK)
-    public MessageResponse update(@Valid @RequestBody NoticeRequestDto request, @PathVariable Long noticeId) {
+    public MessageResponse update(@Valid @RequestBody NoticeRequestDto request, @PathVariable("notice-id") Long noticeId) {
         noticeUpdateService.execute(noticeId, request);
         return MessageResponse.of("공지 수정 성공");
     }
 
-    @GetMapping("/{noticeId}")
+    @GetMapping("/{notice-id}")
     @ResponseStatus(HttpStatus.OK)
-    public NoticeDetailResponse getDetail(@PathVariable Long noticeId) {
+    public NoticeDetailResponse getDetail(@PathVariable("notice-id") Long noticeId) {
         return queryNoticeDetailService.execute(noticeId);
     }
 
@@ -48,9 +48,9 @@ public class NoticeController {
     }
 
 
-    @DeleteMapping("/{noticeId}")
+    @DeleteMapping("/{notice-id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public ResponseEntity<MessageResponse> deleteNotice(@PathVariable("noticeId") Long noticeId) {
+    public ResponseEntity<MessageResponse> deleteNotice(@PathVariable("notice-id") Long noticeId) {
         noticeDeleteService.execute(noticeId);
         return ResponseEntity.ok(
                 new MessageResponse("공지 삭제가 완료되었습니다.")

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/NoticeController.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/NoticeController.java
@@ -1,7 +1,8 @@
 package com.command.toyvillage_server.domain.app.notice.presentation;
 
 import com.command.toyvillage_server.domain.app.notice.presentation.dto.request.NoticeRequestDto;
-import com.command.toyvillage_server.domain.app.notice.presentation.dto.response.NoticeResponseDto;
+import com.command.toyvillage_server.domain.app.notice.presentation.dto.response.NoticeListResponseDto;
+import com.command.toyvillage_server.domain.app.notice.presentation.dto.response.NoticeDetailResponse;
 import com.command.toyvillage_server.domain.app.notice.service.NoticeCreateService;
 import com.command.toyvillage_server.domain.app.notice.service.NoticeDeleteService;
 import com.command.toyvillage_server.domain.app.notice.service.NoticeUpdateService;
@@ -42,7 +43,7 @@ public class NoticeController {
     }
 
     @GetMapping
-    public List<NoticeResponseDto> getList(@PageableDefault(page = 0, size = 10) Pageable pageable) {
+    public List<NoticeListResponseDto> getList(@PageableDefault(page = 0, size = 10) Pageable pageable) {
         return queryNoticeListService.execute(pageable);
     }
 

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/NoticeController.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/NoticeController.java
@@ -37,7 +37,7 @@ public class NoticeController {
 
     @GetMapping("/{noticeId}")
     @ResponseStatus(HttpStatus.OK)
-    public NoticeResponseDto getDetail(@PathVariable Long noticeId) {
+    public NoticeDetailResponse getDetail(@PathVariable Long noticeId) {
         return queryNoticeDetailService.execute(noticeId);
     }
 

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/dto/request/NoticeRequestDto.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/dto/request/NoticeRequestDto.java
@@ -2,8 +2,11 @@ package com.command.toyvillage_server.domain.app.notice.presentation.dto.request
 
 import com.command.toyvillage_server.domain.app.notice.domain.Kind;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class NoticeRequestDto {
@@ -15,4 +18,6 @@ public class NoticeRequestDto {
 
     @NotBlank(message = "공지사항 내용을 입력해주세요.")
     private String content;
+
+    private List<String> files;
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/dto/response/NoticeDetailResponse.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/dto/response/NoticeDetailResponse.java
@@ -2,25 +2,33 @@ package com.command.toyvillage_server.domain.app.notice.presentation.dto.respons
 
 import com.command.toyvillage_server.domain.app.notice.domain.Kind;
 import com.command.toyvillage_server.domain.app.notice.domain.Notice;
+import com.command.toyvillage_server.domain.web.file.presentation.dto.response.FileResponse;
 import lombok.Builder;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Builder
-public record NoticeResponseDto(
+public record NoticeDetailResponse(
     Long id,
     String title,
     Kind kind,
     String content,
-    LocalDate createdAt
+    LocalDate createdAt,
+    List<FileResponse> files
 ) {
-    public static NoticeResponseDto from(Notice notice) {
-        return NoticeResponseDto.builder()
+    public static NoticeDetailResponse from(Notice notice) {
+        return NoticeDetailResponse.builder()
             .id(notice.getId())
             .title(notice.getTitle())
             .kind(notice.getKind())
             .content(notice.getContent())
             .createdAt(notice.getCreatedAt())
+            .files(
+                notice.getFiles().stream()
+                    .map(FileResponse::from)
+                    .toList()
+            )
             .build();
     }
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/dto/response/NoticeListResponseDto.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/dto/response/NoticeListResponseDto.java
@@ -1,0 +1,24 @@
+package com.command.toyvillage_server.domain.app.notice.presentation.dto.response;
+
+import com.command.toyvillage_server.domain.app.notice.domain.Kind;
+import com.command.toyvillage_server.domain.app.notice.domain.Notice;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record NoticeListResponseDto(
+    Long id,
+    String title,
+    Kind kind,
+    LocalDate createdAt
+) {
+    public static NoticeListResponseDto from(Notice notice) {
+        return NoticeListResponseDto.builder()
+            .id(notice.getId())
+            .title(notice.getTitle())
+            .kind(notice.getKind())
+            .createdAt(notice.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/service/NoticeCreateService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/service/NoticeCreateService.java
@@ -3,21 +3,35 @@ package com.command.toyvillage_server.domain.app.notice.service;
 import com.command.toyvillage_server.domain.app.notice.domain.Notice;
 import com.command.toyvillage_server.domain.app.notice.domain.repository.NoticeRepository;
 import com.command.toyvillage_server.domain.app.notice.presentation.dto.request.NoticeRequestDto;
+import com.command.toyvillage_server.domain.web.file.domain.File;
+import com.command.toyvillage_server.domain.web.file.domain.repository.FileRepository;
+import com.command.toyvillage_server.domain.web.file.exception.FileNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class NoticeCreateService {
     private final NoticeRepository noticeRepository;
+    private final FileRepository fileRepository;
 
     @Transactional
     public void execute(NoticeRequestDto request) {
+        List<String> fileKeys = request.getFiles() == null ? new ArrayList<>() : request.getFiles();
+        List<File> files = fileRepository.findAllByFileKeyIn(fileKeys);
+        if (files.size() != fileKeys.size())
+            throw FileNotFoundException.EXCEPTION;
+
+
         Notice notice = Notice.create(
             request.getTitle(),
             request.getKind(),
-            request.getContent()
+            request.getContent(),
+            files
         );
 
         noticeRepository.save(notice);

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/service/NoticeUpdateService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/service/NoticeUpdateService.java
@@ -4,21 +4,34 @@ import com.command.toyvillage_server.domain.app.notice.domain.Notice;
 import com.command.toyvillage_server.domain.app.notice.domain.repository.NoticeRepository;
 import com.command.toyvillage_server.domain.app.notice.exception.NoticeNotFoundException;
 import com.command.toyvillage_server.domain.app.notice.presentation.dto.request.NoticeRequestDto;
+import com.command.toyvillage_server.domain.web.file.domain.File;
+import com.command.toyvillage_server.domain.web.file.domain.repository.FileRepository;
+import com.command.toyvillage_server.domain.web.file.exception.FileNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
 public class NoticeUpdateService {
     private final NoticeRepository noticeRepository;
+    private final FileRepository fileRepository;
+
 
     @Transactional
     public void execute(Long id, NoticeRequestDto dto) {
+        List<String> fileKeys = dto.getFiles() == null ? new ArrayList<>() : dto.getFiles();
+        List<File> files = fileRepository.findAllByFileKeyIn(fileKeys);
+        if (files.size() != fileKeys.size())
+            throw FileNotFoundException.EXCEPTION;
+
         Notice notice = noticeRepository.findById(id)
             .orElseThrow(() -> NoticeNotFoundException.EXCEPTION);
 
-        notice.update(dto.getTitle(), dto.getKind(), dto.getContent());
+        notice.update(dto.getTitle(), dto.getKind(), dto.getContent(),  files);
         noticeRepository.save(notice);
     }
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/service/NoticeUpdateService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/service/NoticeUpdateService.java
@@ -11,7 +11,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -23,13 +22,16 @@ public class NoticeUpdateService {
 
     @Transactional
     public void execute(Long id, NoticeRequestDto dto) {
-        List<String> fileKeys = dto.getFiles() == null ? new ArrayList<>() : dto.getFiles();
-        List<File> files = fileRepository.findAllByFileKeyIn(fileKeys);
-        if (files.size() != fileKeys.size())
-            throw FileNotFoundException.EXCEPTION;
-
         Notice notice = noticeRepository.findById(id)
             .orElseThrow(() -> NoticeNotFoundException.EXCEPTION);
+
+        List<File> files = null;
+        if (dto.getFiles() != null) {
+            List<String> fileKeys = dto.getFiles();
+            files = fileRepository.findAllByFileKeyIn(fileKeys);
+            if (files.size() != fileKeys.size())
+                throw FileNotFoundException.EXCEPTION;
+        }
 
         notice.update(dto.getTitle(), dto.getKind(), dto.getContent(),  files);
         noticeRepository.save(notice);

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/service/QueryNoticeDetailService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/service/QueryNoticeDetailService.java
@@ -3,7 +3,7 @@ package com.command.toyvillage_server.domain.app.notice.service;
 import com.command.toyvillage_server.domain.app.notice.domain.Notice;
 import com.command.toyvillage_server.domain.app.notice.domain.repository.NoticeRepository;
 import com.command.toyvillage_server.domain.app.notice.exception.NoticeNotFoundException;
-import com.command.toyvillage_server.domain.app.notice.presentation.dto.response.NoticeResponseDto;
+import com.command.toyvillage_server.domain.app.notice.presentation.dto.response.NoticeDetailResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,10 +14,10 @@ public class QueryNoticeDetailService {
     private final NoticeRepository noticeRepository;
 
     @Transactional(readOnly = true)
-    public NoticeResponseDto execute(Long id) {
+    public NoticeDetailResponse execute(Long id) {
         Notice notice = noticeRepository.findById(id)
             .orElseThrow(() -> NoticeNotFoundException.EXCEPTION);
 
-        return NoticeResponseDto.from(notice);
+        return NoticeDetailResponse.from(notice);
     }
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/service/QueryNoticeListService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/service/QueryNoticeListService.java
@@ -1,7 +1,7 @@
 package com.command.toyvillage_server.domain.app.notice.service;
 
 import com.command.toyvillage_server.domain.app.notice.domain.repository.NoticeRepository;
-import com.command.toyvillage_server.domain.app.notice.presentation.dto.response.NoticeResponseDto;
+import com.command.toyvillage_server.domain.app.notice.presentation.dto.response.NoticeListResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -17,7 +17,7 @@ public class QueryNoticeListService {
     private final NoticeRepository noticeRepository;
 
     @Transactional(readOnly = true)
-    public List<NoticeResponseDto> execute(Pageable p) {
+    public List<NoticeListResponseDto> execute(Pageable p) {
         Pageable pageable = PageRequest.of(
             p.getPageNumber(),
             p.getPageSize(),
@@ -25,7 +25,7 @@ public class QueryNoticeListService {
         );
 
         return noticeRepository.findAll(pageable)
-            .map(NoticeResponseDto::from)
+            .map(NoticeListResponseDto::from)
             .toList();
     }
 }


### PR DESCRIPTION
### 변경 사항
- notice에 file key를 통해 연결할수 있도록 수정
- Create / Update시 file key 연결
- 조회시 FileResponse로 연결되도록 수정 및 List, Detail 2개로 나눔

### 관련 이슈
resolved #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 공지 작성/수정 시 첨부파일을 함께 등록하고 반영할 수 있습니다.
  * 첨부파일을 포함한 공지 상세 정보를 확인할 수 있습니다.
* **개선 사항**
  * 요청한 첨부파일 키와 실제 파일이 일치하지 않으면 요청이 실패할 수 있습니다.
  * 공지 목록은 제목, 종류, 작성일 등 요약 정보만 표시됩니다.
  * 공지 상세 조회는 첨부파일 목록까지 포함해 제공되며, 상세/목록 응답 형식이 분리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->