### PR TITLE
단체예약 권한 및 삭제 APi 구현

### DIFF
--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/domain/repository/ReservationPermissionRepository.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/domain/repository/ReservationPermissionRepository.java
@@ -2,20 +2,20 @@ package com.command.toyvillage_server.domain.app.reservation.domain.repository;
 
 import com.command.toyvillage_server.domain.app.reservation.domain.Reservation;
 import com.command.toyvillage_server.domain.app.reservation.domain.ReservationPermission;
-import com.command.toyvillage_server.domain.common.auth.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReservationPermissionRepository extends JpaRepository<ReservationPermission, Long> {
-    boolean existsByReservationIdAndUserId(Long reservationId, Long userId);
-
-    void deleteByReservationIdAndUserId(Long reservationId, Long userId);
+    boolean existsByReservation_IdAndUser_Id(Long reservationId, Long userId);
 
     @Query("select rp.reservation from ReservationPermission rp where rp.user.id = :userId")
     List<Reservation> findReservationsByUserId(@Param("userId") Long userId);
 
-    List<ReservationPermission> findAllByReservationId(Long reservationId);
+    List<ReservationPermission> findAllByReservation_Id(Long reservationId);
+
+    Optional<ReservationPermission> findByReservation_IdAndUser_Id(Long reservationId, Long userId);
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/domain/repository/ReservationPermissionRepository.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/domain/repository/ReservationPermissionRepository.java
@@ -2,6 +2,7 @@ package com.command.toyvillage_server.domain.app.reservation.domain.repository;
 
 import com.command.toyvillage_server.domain.app.reservation.domain.Reservation;
 import com.command.toyvillage_server.domain.app.reservation.domain.ReservationPermission;
+import com.command.toyvillage_server.domain.common.auth.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,8 +11,11 @@ import java.util.List;
 
 public interface ReservationPermissionRepository extends JpaRepository<ReservationPermission, Long> {
     boolean existsByReservationIdAndUserId(Long reservationId, Long userId);
+
     void deleteByReservationIdAndUserId(Long reservationId, Long userId);
 
     @Query("select rp.reservation from ReservationPermission rp where rp.user.id = :userId")
     List<Reservation> findReservationsByUserId(@Param("userId") Long userId);
+
+    List<User> findAllByReservationId(Long reservationId);
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/domain/repository/ReservationPermissionRepository.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/domain/repository/ReservationPermissionRepository.java
@@ -5,7 +5,6 @@ import com.command.toyvillage_server.domain.app.reservation.domain.ReservationPe
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/domain/repository/ReservationPermissionRepository.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/domain/repository/ReservationPermissionRepository.java
@@ -17,5 +17,5 @@ public interface ReservationPermissionRepository extends JpaRepository<Reservati
     @Query("select rp.reservation from ReservationPermission rp where rp.user.id = :userId")
     List<Reservation> findReservationsByUserId(@Param("userId") Long userId);
 
-    List<User> findAllByReservationId(Long reservationId);
+    List<ReservationPermission> findAllByReservationId(Long reservationId);
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/exception/ReservationPermissionNotFoundException.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/exception/ReservationPermissionNotFoundException.java
@@ -1,0 +1,13 @@
+package com.command.toyvillage_server.domain.app.reservation.exception;
+
+import com.command.toyvillage_server.global.error.exception.ErrorCode;
+import com.command.toyvillage_server.global.error.exception.ToyVillageException;
+
+public class ReservationPermissionNotFoundException extends ToyVillageException {
+    public static final ReservationPermissionNotFoundException EXCEPTION =
+        new ReservationPermissionNotFoundException();
+
+    private ReservationPermissionNotFoundException() {
+        super(ErrorCode.RESERVATION_PERMISSION_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/presentation/ReservationController.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/presentation/ReservationController.java
@@ -3,11 +3,13 @@ package com.command.toyvillage_server.domain.app.reservation.presentation;
 import com.command.toyvillage_server.domain.app.reservation.presentation.dto.response.ReservationListResponse;
 import com.command.toyvillage_server.domain.app.reservation.presentation.dto.response.ReservationPermissionResponse;
 import com.command.toyvillage_server.domain.app.reservation.presentation.dto.response.ReservationResponse;
+import com.command.toyvillage_server.domain.app.reservation.service.ReservationPermissionDeleteService;
 import com.command.toyvillage_server.domain.app.reservation.service.ReservationPermissionQueryListService;
 import com.command.toyvillage_server.domain.app.reservation.service.ReservationPermissionSettingService;
 import com.command.toyvillage_server.domain.app.reservation.service.ReservationQueryListService;
 import com.command.toyvillage_server.domain.app.reservation.service.ReservationQueryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -20,6 +22,7 @@ public class ReservationController {
     private final ReservationQueryListService reservationQueryListService;
     private final ReservationPermissionSettingService reservationPermissionSettingService;
     private final ReservationPermissionQueryListService reservationPermissionQueryListService;
+    private final ReservationPermissionDeleteService reservationPermissionDeleteService;
 
     @GetMapping("/{id}")
     public ReservationResponse getDetail(@PathVariable Long id) {
@@ -43,5 +46,14 @@ public class ReservationController {
     @GetMapping("/permission/{reservationId}")
     public List<ReservationPermissionResponse> getPermissionList(@PathVariable("reservationId") Long reservationId) {
         return reservationPermissionQueryListService.execute(reservationId);
+    }
+
+    @DeleteMapping("/permission/{reservationId}/{userId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deletePermission(
+        @PathVariable Long reservationId,
+        @PathVariable Long userId
+    ) {
+        reservationPermissionDeleteService.execute(reservationId, userId);
     }
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/presentation/ReservationController.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/presentation/ReservationController.java
@@ -1,7 +1,9 @@
 package com.command.toyvillage_server.domain.app.reservation.presentation;
 
 import com.command.toyvillage_server.domain.app.reservation.presentation.dto.response.ReservationListResponse;
+import com.command.toyvillage_server.domain.app.reservation.presentation.dto.response.ReservationPermissionResponse;
 import com.command.toyvillage_server.domain.app.reservation.presentation.dto.response.ReservationResponse;
+import com.command.toyvillage_server.domain.app.reservation.service.ReservationPermissionQueryListService;
 import com.command.toyvillage_server.domain.app.reservation.service.ReservationPermissionSettingService;
 import com.command.toyvillage_server.domain.app.reservation.service.ReservationQueryListService;
 import com.command.toyvillage_server.domain.app.reservation.service.ReservationQueryService;
@@ -17,6 +19,7 @@ public class ReservationController {
     private final ReservationQueryService reservationQueryService;
     private final ReservationQueryListService reservationQueryListService;
     private final ReservationPermissionSettingService reservationPermissionSettingService;
+    private final ReservationPermissionQueryListService reservationPermissionQueryListService;
 
     @GetMapping("/{id}")
     public ReservationResponse getDetail(@PathVariable Long id) {
@@ -37,4 +40,8 @@ public class ReservationController {
         reservationPermissionSettingService.execute(reservationId, userId, reservationPermission);
     }
 
+    @GetMapping("/permission/{reservationId}")
+    public List<ReservationPermissionResponse> getPermissionList(@PathVariable("reservationId") Long reservationId) {
+        return reservationPermissionQueryListService.execute(reservationId);
+    }
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/presentation/ReservationController.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/presentation/ReservationController.java
@@ -8,6 +8,7 @@ import com.command.toyvillage_server.domain.app.reservation.service.ReservationP
 import com.command.toyvillage_server.domain.app.reservation.service.ReservationPermissionSettingService;
 import com.command.toyvillage_server.domain.app.reservation.service.ReservationQueryListService;
 import com.command.toyvillage_server.domain.app.reservation.service.ReservationQueryService;
+import com.command.toyvillage_server.global.common.response.MessageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -50,10 +51,11 @@ public class ReservationController {
 
     @DeleteMapping("/permission/{reservationId}/{userId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deletePermission(
+    public MessageResponse deletePermission(
         @PathVariable Long reservationId,
         @PathVariable Long userId
     ) {
         reservationPermissionDeleteService.execute(reservationId, userId);
+        return MessageResponse.of("단체예약 삭제가 완료되었습니다.");
     }
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/presentation/dto/response/ReservationPermissionResponse.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/presentation/dto/response/ReservationPermissionResponse.java
@@ -1,0 +1,14 @@
+package com.command.toyvillage_server.domain.app.reservation.presentation.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record ReservationPermissionResponse(
+    String name
+) {
+    public static ReservationPermissionResponse of(String name){
+        return ReservationPermissionResponse.builder()
+            .name(name)
+            .build();
+    }
+}

--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/presentation/dto/response/ReservationPermissionResponse.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/presentation/dto/response/ReservationPermissionResponse.java
@@ -4,10 +4,12 @@ import lombok.Builder;
 
 @Builder
 public record ReservationPermissionResponse(
+    Long userId,
     String name
 ) {
-    public static ReservationPermissionResponse of(String name){
+    public static ReservationPermissionResponse of(Long userId, String name){
         return ReservationPermissionResponse.builder()
+            .userId(userId)
             .name(name)
             .build();
     }

--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionDeleteService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionDeleteService.java
@@ -1,0 +1,23 @@
+package com.command.toyvillage_server.domain.app.reservation.service;
+
+import com.command.toyvillage_server.domain.app.reservation.domain.ReservationPermission;
+import com.command.toyvillage_server.domain.app.reservation.domain.repository.ReservationPermissionRepository;
+import com.command.toyvillage_server.domain.app.reservation.exception.ReservationPermissionNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationPermissionDeleteService {
+    private final ReservationPermissionRepository reservationPermissionRepository;
+
+    @Transactional
+    public void execute(Long reservationId, Long userId) {
+        ReservationPermission permission = reservationPermissionRepository
+            .findByReservation_IdAndUser_Id(reservationId, userId)
+            .orElseThrow(() -> ReservationPermissionNotFoundException.EXCEPTION);
+
+        reservationPermissionRepository.delete(permission);
+    }
+}

--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionQueryListService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionQueryListService.java
@@ -1,0 +1,11 @@
+package com.command.toyvillage_server.domain.app.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationPermissionQueryListService {
+
+
+}

--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionQueryListService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionQueryListService.java
@@ -1,6 +1,7 @@
 package com.command.toyvillage_server.domain.app.reservation.service;
 
 import com.command.toyvillage_server.domain.app.reservation.domain.Reservation;
+import com.command.toyvillage_server.domain.app.reservation.domain.ReservationPermission;
 import com.command.toyvillage_server.domain.app.reservation.domain.repository.ReservationPermissionRepository;
 import com.command.toyvillage_server.domain.app.reservation.domain.repository.ReservationRepository;
 import com.command.toyvillage_server.domain.app.reservation.exception.ReservationNotFoundException;
@@ -23,14 +24,14 @@ public class ReservationPermissionQueryListService {
 
     @Transactional(readOnly = true)
     public List<ReservationPermissionResponse> execute(Long reservationId) {
-        Reservation reservation = reservationRepository.findById(reservationId)
+        reservationRepository.findById(reservationId)
             .orElseThrow(() -> ReservationNotFoundException.EXCEPTION);
 
-        List<User> users = reservationPermissionRepository.findAllByReservationId(reservationId);
+        List<ReservationPermission> users = reservationPermissionRepository.findAllByReservationId(reservationId);
 
         List<ReservationPermissionResponse> responses = new ArrayList<>();
-        for(User user : users) {
-            ReservationPermissionResponse response = ReservationPermissionResponse.of(user.getName());
+        for(ReservationPermission user : users) {
+            ReservationPermissionResponse response = ReservationPermissionResponse.of(user.getUser().getName());
             responses.add(response);
         }
 

--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionQueryListService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionQueryListService.java
@@ -1,11 +1,38 @@
 package com.command.toyvillage_server.domain.app.reservation.service;
 
+import com.command.toyvillage_server.domain.app.reservation.domain.Reservation;
+import com.command.toyvillage_server.domain.app.reservation.domain.repository.ReservationPermissionRepository;
+import com.command.toyvillage_server.domain.app.reservation.domain.repository.ReservationRepository;
+import com.command.toyvillage_server.domain.app.reservation.exception.ReservationNotFoundException;
+import com.command.toyvillage_server.domain.app.reservation.presentation.dto.response.ReservationPermissionResponse;
+import com.command.toyvillage_server.domain.common.auth.user.domain.User;
+import com.command.toyvillage_server.domain.common.auth.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ReservationPermissionQueryListService {
+    private final ReservationRepository reservationRepository;
+    private final UserRepository userRepository;
+    private final ReservationPermissionRepository reservationPermissionRepository;
 
 
+    public List<ReservationPermissionResponse> execute(Long reservationId) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+            .orElseThrow(() -> ReservationNotFoundException.EXCEPTION);
+
+        List<User> users = reservationPermissionRepository.findAllByReservationId(reservationId);
+
+        List<ReservationPermissionResponse> responses = new ArrayList<>();
+        for(User user : users) {
+            ReservationPermissionResponse response = ReservationPermissionResponse.of(user.getName());
+            responses.add(response);
+        }
+
+        return responses;
+    }
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionQueryListService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionQueryListService.java
@@ -23,7 +23,7 @@ public class ReservationPermissionQueryListService {
 
         return reservationPermissionRepository.findAllByReservation_Id(reservationId)
             .stream()
-            .map(permission -> ReservationPermissionResponse.of(permission.getUser().getName()))
+            .map(permission -> ReservationPermissionResponse.of(permission.getUser().getId(), permission.getUser().getName()))
             .toList();
     }
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionQueryListService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionQueryListService.java
@@ -1,25 +1,19 @@
 package com.command.toyvillage_server.domain.app.reservation.service;
 
-import com.command.toyvillage_server.domain.app.reservation.domain.Reservation;
-import com.command.toyvillage_server.domain.app.reservation.domain.ReservationPermission;
 import com.command.toyvillage_server.domain.app.reservation.domain.repository.ReservationPermissionRepository;
 import com.command.toyvillage_server.domain.app.reservation.domain.repository.ReservationRepository;
 import com.command.toyvillage_server.domain.app.reservation.exception.ReservationNotFoundException;
 import com.command.toyvillage_server.domain.app.reservation.presentation.dto.response.ReservationPermissionResponse;
-import com.command.toyvillage_server.domain.common.auth.user.domain.User;
-import com.command.toyvillage_server.domain.common.auth.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ReservationPermissionQueryListService {
     private final ReservationRepository reservationRepository;
-    private final UserRepository userRepository;
     private final ReservationPermissionRepository reservationPermissionRepository;
 
     @Transactional(readOnly = true)
@@ -27,14 +21,9 @@ public class ReservationPermissionQueryListService {
         reservationRepository.findById(reservationId)
             .orElseThrow(() -> ReservationNotFoundException.EXCEPTION);
 
-        List<ReservationPermission> users = reservationPermissionRepository.findAllByReservationId(reservationId);
-
-        List<ReservationPermissionResponse> responses = new ArrayList<>();
-        for(ReservationPermission user : users) {
-            ReservationPermissionResponse response = ReservationPermissionResponse.of(user.getUser().getName());
-            responses.add(response);
-        }
-
-        return responses;
+        return reservationPermissionRepository.findAllByReservation_Id(reservationId)
+            .stream()
+            .map(permission -> ReservationPermissionResponse.of(permission.getUser().getName()))
+            .toList();
     }
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionQueryListService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionQueryListService.java
@@ -9,6 +9,7 @@ import com.command.toyvillage_server.domain.common.auth.user.domain.User;
 import com.command.toyvillage_server.domain.common.auth.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,7 +21,7 @@ public class ReservationPermissionQueryListService {
     private final UserRepository userRepository;
     private final ReservationPermissionRepository reservationPermissionRepository;
 
-
+    @Transactional(readOnly = true)
     public List<ReservationPermissionResponse> execute(Long reservationId) {
         Reservation reservation = reservationRepository.findById(reservationId)
             .orElseThrow(() -> ReservationNotFoundException.EXCEPTION);

--- a/src/main/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionSettingService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionSettingService.java
@@ -30,12 +30,12 @@ public class ReservationPermissionSettingService {
         if (permission) {
             grant(reservation, user);
         } else {
-            reservationPermissionRepository.deleteByReservationIdAndUserId(reservationId, userId);
+            revoke(reservationId, userId);
         }
     }
 
     private void grant(Reservation reservation, User user) {
-        if (!reservationPermissionRepository.existsByReservationIdAndUserId(reservation.getId(), user.getId())) {
+        if (!reservationPermissionRepository.existsByReservation_IdAndUser_Id(reservation.getId(), user.getId())) {
             reservationPermissionRepository.save(
                 ReservationPermission.builder()
                     .reservation(reservation)
@@ -43,5 +43,11 @@ public class ReservationPermissionSettingService {
                     .build()
             );
         }
+    }
+
+    private void revoke(Long reservationId, Long userId) {
+        reservationPermissionRepository
+            .findByReservation_IdAndUser_Id(reservationId, userId)
+            .ifPresent(reservationPermissionRepository::delete);
     }
 }

--- a/src/main/java/com/command/toyvillage_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/command/toyvillage_server/global/config/SecurityConfig.java
@@ -97,7 +97,10 @@ public class SecurityConfig {
                     .requestMatchers("/join-team", "/join-team/**").hasRole("ADMIN")
 
                     //reservation
-                    .requestMatchers( "/reservation", "/reservation/**", "/reservation/permission/**").authenticated()
+                    .requestMatchers("/reservation/permission/**").hasRole("ADMIN")
+                    .requestMatchers(HttpMethod.GET, "/reservation", "/reservation/**").authenticated()
+                    .requestMatchers("/reservation", "/reservation/**").hasRole("ADMIN")
+
                     // close day
                     .requestMatchers(HttpMethod.GET, "/close-day", "/close-day/**").permitAll()
                     .requestMatchers("/close-day", "/close-day/**").authenticated()

--- a/src/main/java/com/command/toyvillage_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/command/toyvillage_server/global/config/SecurityConfig.java
@@ -97,8 +97,7 @@ public class SecurityConfig {
                     .requestMatchers("/join-team", "/join-team/**").hasRole("ADMIN")
 
                     //reservation
-                    .requestMatchers("/reservation", "/reservation/**").authenticated()
-
+                    .requestMatchers( "/reservation", "/reservation/**", "/reservation/permission/**").authenticated()
                     // close day
                     .requestMatchers(HttpMethod.GET, "/close-day", "/close-day/**").permitAll()
                     .requestMatchers("/close-day", "/close-day/**").authenticated()

--- a/src/main/java/com/command/toyvillage_server/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/command/toyvillage_server/global/error/exception/ErrorCode.java
@@ -68,6 +68,7 @@ public enum ErrorCode {
 
     // reservation
     RESERVATION_NOT_FOUND(404, "존재하지 않는 단체예약 목록입니다."),
+    RESERVATION_PERMISSION_NOT_FOUND(404, "존재하지 않는 단체예약 조회 권한입니다."),
 
     // user
     USER_NOT_FOUND(404, "존재하지 않는 유저입니다."),

--- a/src/test/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionDeleteServiceTest.java
+++ b/src/test/java/com/command/toyvillage_server/domain/app/reservation/service/ReservationPermissionDeleteServiceTest.java
@@ -1,0 +1,64 @@
+package com.command.toyvillage_server.domain.app.reservation.service;
+
+import com.command.toyvillage_server.domain.app.reservation.domain.ReservationPermission;
+import com.command.toyvillage_server.domain.app.reservation.domain.repository.ReservationPermissionRepository;
+import com.command.toyvillage_server.domain.app.reservation.exception.ReservationPermissionNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationPermissionDeleteServiceTest {
+
+    @Mock
+    private ReservationPermissionRepository reservationPermissionRepository;
+
+    @Mock
+    private ReservationPermission reservationPermission;
+
+    private ReservationPermissionDeleteService reservationPermissionDeleteService;
+
+    @BeforeEach
+    void setUp() {
+        reservationPermissionDeleteService =
+            new ReservationPermissionDeleteService(reservationPermissionRepository);
+    }
+
+    @Test
+    void 예약과_사용자의_조회_권한을_삭제한다() {
+        Long reservationId = 1L;
+        Long userId = 2L;
+        when(reservationPermissionRepository.findByReservation_IdAndUser_Id(reservationId, userId))
+            .thenReturn(Optional.of(reservationPermission));
+
+        reservationPermissionDeleteService.execute(reservationId, userId);
+
+        verify(reservationPermissionRepository).delete(reservationPermission);
+    }
+
+    @Test
+    void 조회_권한이_없으면_예외가_발생한다() {
+        Long reservationId = 1L;
+        Long userId = 2L;
+        when(reservationPermissionRepository.findByReservation_IdAndUser_Id(reservationId, userId))
+            .thenReturn(Optional.empty());
+
+        ReservationPermissionNotFoundException exception = assertThrows(
+            ReservationPermissionNotFoundException.class,
+            () -> reservationPermissionDeleteService.execute(reservationId, userId)
+        );
+
+        assertSame(ReservationPermissionNotFoundException.EXCEPTION, exception);
+        verify(reservationPermissionRepository, never()).delete(reservationPermission);
+    }
+}


### PR DESCRIPTION
### **📝 작업 내용**

- 단체예약 및 삭제 APi 구현

### **⚠ 수정 사항 (기존 코드 변경 시)**

- 수정 이유 및 변경 내용

### **✅ 테스트 결과**

- 정상 동작 확인
- 예외 테스트 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 예약 ID별 권한 목록을 조회할 수 있습니다.
  * 특정 사용자 권한을 삭제할 수 있습니다. (삭제 후 응답 제공)

* **권한 및 보안**
  * `/reservation/permission/**` 엔드포인트는 관리자 권한만 접근할 수 있습니다.
  * `/reservation` 및 `/reservation/**`는 GET은 인증 필요, 그 외 요청은 관리자 권한이 필요합니다.

* **오류 수정**
  * 존재하지 않는 예약 권한에 대해 404 오류와 명확한 메시지를 반환합니다.

* **테스트**
  * 권한 삭제 서비스 동작에 대한 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->