### PR TITLE
Feature/100 자료실 조회시 카테고리 필터링 추가

### DIFF
--- a/src/main/java/com/command/toyvillage_server/domain/app/document/domain/repository/DocumentRepository.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/document/domain/repository/DocumentRepository.java
@@ -1,10 +1,15 @@
 package com.command.toyvillage_server.domain.app.document.domain.repository;
 
 import com.command.toyvillage_server.domain.app.document.domain.Document;
+import com.command.toyvillage_server.domain.app.document.domain.DocumentType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface DocumentRepository extends JpaRepository<Document, Long> {
     Page<Document> getAllByTitleContainsIgnoreCase(String title, Pageable pageable);
+
+    Page<Document> getAllByTitleContainsIgnoreCaseAndTypeIn(String title, List<DocumentType> types, Pageable pageable);
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/document/presentation/DocumentController.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/document/presentation/DocumentController.java
@@ -1,5 +1,6 @@
 package com.command.toyvillage_server.domain.app.document.presentation;
 
+import com.command.toyvillage_server.domain.app.document.domain.DocumentType;
 import com.command.toyvillage_server.domain.app.document.presentation.dto.request.DocumentRequest;
 import com.command.toyvillage_server.domain.app.document.presentation.dto.response.DocumentDetailResponse;
 import com.command.toyvillage_server.domain.app.document.presentation.dto.response.DocumentListResponse;
@@ -40,9 +41,10 @@ public class DocumentController {
     @GetMapping
     public List<DocumentListResponse> getList(
         @RequestParam(required = false, defaultValue = "") String keyword,
+        @RequestParam(required = false) List<DocumentType> types,
         Pageable pageable
     ) {
-        return queryDocumentListService.execute(keyword, pageable);
+        return queryDocumentListService.execute(keyword, types, pageable);
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/command/toyvillage_server/domain/app/document/service/QueryDocumentListService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/document/service/QueryDocumentListService.java
@@ -1,8 +1,11 @@
 package com.command.toyvillage_server.domain.app.document.service;
 
+import com.command.toyvillage_server.domain.app.document.domain.Document;
+import com.command.toyvillage_server.domain.app.document.domain.DocumentType;
 import com.command.toyvillage_server.domain.app.document.domain.repository.DocumentRepository;
 import com.command.toyvillage_server.domain.app.document.presentation.dto.response.DocumentListResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -17,7 +20,7 @@ public class QueryDocumentListService {
     private final DocumentRepository documentRepository;
 
     @Transactional(readOnly = true)
-    public List<DocumentListResponse> execute(String keyword, Pageable p) {
+    public List<DocumentListResponse> execute(String keyword, List<DocumentType> types, Pageable p) {
         Pageable pageable = PageRequest.of(
             p.getPageNumber(),
             p.getPageSize(),
@@ -30,7 +33,11 @@ public class QueryDocumentListService {
             )
         );
 
-        return documentRepository.getAllByTitleContainsIgnoreCase(keyword, pageable)
+        Page<Document> documents = types == null || types.isEmpty()
+            ? documentRepository.getAllByTitleContainsIgnoreCase(keyword, pageable)
+            : documentRepository.getAllByTitleContainsIgnoreCaseAndTypeIn(keyword, types, pageable);
+
+        return documents
             .map(DocumentListResponse::from)
             .toList();
     }


### PR DESCRIPTION
### 작업 내용
- 자료실조회시에 카테고리 필터링, queryString 추가
### 관련 이슈
resolved #100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 문서 목록 조회 시 문서 유형별 필터링을 지원합니다.
  * 키워드 검색과 문서 유형 필터를 함께 사용할 수 있습니다.
  * 기존 키워드 검색 및 페이지네이션 기능은 그대로 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->