### PR TITLE
Feature/106 전체 페이지 개수를 페이지네이션시 조회에 추가

### DIFF
--- a/src/main/java/com/command/toyvillage_server/domain/app/document/presentation/DocumentController.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/document/presentation/DocumentController.java
@@ -39,7 +39,7 @@ public class DocumentController {
     }
 
     @GetMapping
-    public List<DocumentListResponse> getList(
+    public DocumentListResponse getList(
         @RequestParam(required = false, defaultValue = "") String keyword,
         @RequestParam(required = false) List<DocumentType> types,
         Pageable pageable

--- a/src/main/java/com/command/toyvillage_server/domain/app/document/presentation/dto/response/DocumentListResponse.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/document/presentation/dto/response/DocumentListResponse.java
@@ -3,22 +3,39 @@ package com.command.toyvillage_server.domain.app.document.presentation.dto.respo
 import com.command.toyvillage_server.domain.app.document.domain.Document;
 import com.command.toyvillage_server.domain.app.document.domain.DocumentType;
 import lombok.Builder;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Builder
 public record DocumentListResponse(
-    Long id,
-    String title,
-    DocumentType type,
-    LocalDateTime createdAt
+    List<DocumentResponse> documents,
+    int totalPageSize
 ) {
-    public static DocumentListResponse from(Document document) {
+
+    public static DocumentListResponse from(Page<Document> documents) {
         return DocumentListResponse.builder()
-            .id(document.getId())
-            .title(document.getTitle())
-            .type(document.getType())
-            .createdAt(document.getCreatedAt())
+            .documents(documents.map(DocumentResponse::from).toList())
+            .totalPageSize(documents.getTotalPages())
             .build();
     }
+
+    @Builder
+    private record DocumentResponse(
+        Long id,
+        String title,
+        DocumentType type,
+        LocalDateTime createdAt
+    ) {
+        public static DocumentResponse from(Document document) {
+            return DocumentResponse.builder()
+                .id(document.getId())
+                .title(document.getTitle())
+                .type(document.getType())
+                .createdAt(document.getCreatedAt())
+                .build();
+        }
+    }
+
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/document/service/QueryDocumentListService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/document/service/QueryDocumentListService.java
@@ -20,7 +20,7 @@ public class QueryDocumentListService {
     private final DocumentRepository documentRepository;
 
     @Transactional(readOnly = true)
-    public List<DocumentListResponse> execute(String keyword, List<DocumentType> types, Pageable p) {
+    public DocumentListResponse execute(String keyword, List<DocumentType> types, Pageable p) {
         Pageable pageable = PageRequest.of(
             p.getPageNumber(),
             p.getPageSize(),
@@ -37,8 +37,6 @@ public class QueryDocumentListService {
             ? documentRepository.getAllByTitleContainsIgnoreCase(keyword, pageable)
             : documentRepository.getAllByTitleContainsIgnoreCaseAndTypeIn(keyword, types, pageable);
 
-        return documents
-            .map(DocumentListResponse::from)
-            .toList();
+        return DocumentListResponse.from(documents);
     }
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/NoticeController.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/NoticeController.java
@@ -17,8 +17,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/notice")
@@ -43,7 +41,7 @@ public class NoticeController {
     }
 
     @GetMapping
-    public List<NoticeListResponseDto> getList(@PageableDefault(page = 0, size = 10) Pageable pageable) {
+    public NoticeListResponseDto getList(@PageableDefault(page = 0, size = 10) Pageable pageable) {
         return queryNoticeListService.execute(pageable);
     }
 

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/dto/response/NoticeListResponseDto.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/presentation/dto/response/NoticeListResponseDto.java
@@ -3,22 +3,37 @@ package com.command.toyvillage_server.domain.app.notice.presentation.dto.respons
 import com.command.toyvillage_server.domain.app.notice.domain.Kind;
 import com.command.toyvillage_server.domain.app.notice.domain.Notice;
 import lombok.Builder;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Builder
 public record NoticeListResponseDto(
-    Long id,
-    String title,
-    Kind kind,
-    LocalDate createdAt
+    List<NoticeResponse> notices,
+    int totalPageSize
 ) {
-    public static NoticeListResponseDto from(Notice notice) {
+    public static NoticeListResponseDto from(Page<Notice> notices) {
         return NoticeListResponseDto.builder()
-            .id(notice.getId())
-            .title(notice.getTitle())
-            .kind(notice.getKind())
-            .createdAt(notice.getCreatedAt())
+            .notices(notices.map(NoticeResponse::from).toList())
+            .totalPageSize(notices.getTotalPages())
             .build();
+    }
+
+    @Builder
+    private record NoticeResponse(
+        Long id,
+        String title,
+        Kind kind,
+        LocalDate createdAt
+    ) {
+        public static NoticeResponse from(Notice notice) {
+            return NoticeResponse.builder()
+                .id(notice.getId())
+                .title(notice.getTitle())
+                .kind(notice.getKind())
+                .createdAt(notice.getCreatedAt())
+                .build();
+        }
     }
 }

--- a/src/main/java/com/command/toyvillage_server/domain/app/notice/service/QueryNoticeListService.java
+++ b/src/main/java/com/command/toyvillage_server/domain/app/notice/service/QueryNoticeListService.java
@@ -1,15 +1,15 @@
 package com.command.toyvillage_server.domain.app.notice.service;
 
+import com.command.toyvillage_server.domain.app.notice.domain.Notice;
 import com.command.toyvillage_server.domain.app.notice.domain.repository.NoticeRepository;
 import com.command.toyvillage_server.domain.app.notice.presentation.dto.response.NoticeListResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -17,15 +17,15 @@ public class QueryNoticeListService {
     private final NoticeRepository noticeRepository;
 
     @Transactional(readOnly = true)
-    public List<NoticeListResponseDto> execute(Pageable p) {
+    public NoticeListResponseDto execute(Pageable p) {
         Pageable pageable = PageRequest.of(
             p.getPageNumber(),
             p.getPageSize(),
             p.getSortOr(Sort.by(Sort.Direction.DESC, "id"))
         );
 
-        return noticeRepository.findAll(pageable)
-            .map(NoticeListResponseDto::from)
-            .toList();
+        Page<Notice> notices = noticeRepository.findAll(pageable);
+
+        return NoticeListResponseDto.from(notices);
     }
 }


### PR DESCRIPTION
### 작업 내용
- Notice, Document 전체조회시 페이지 전체 개수도 조회되도록 변경
- 기존 ListResponse를 리스트에서 객체 형태로 반환하도록 변경
### 관련 이슈
resolved #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 문서 및 공지사항 목록 응답이 페이지 단위 구조로 개선되었습니다.
  * 목록 항목과 함께 전체 페이지 수가 제공됩니다.
  * 문서와 공지사항의 개별 항목 정보(식별자, 제목, 유형, 작성일 등)는 기존과 동일하게 확인할 수 있습니다.
  * 목록 조회 결과 형식이 변경되어 클라이언트는 항목 목록과 페이지 정보를 함께 처리할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->