### PR TITLE
chore : Dockerfile에서 직접 빌드하도록 변경

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+.gradle
+.idea
+build
+.env
+src/main/resources/.env
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,23 @@
-FROM eclipse-temurin:21-jdk
+# syntax=docker/dockerfile:1
+
+FROM eclipse-temurin:21-jdk AS builder
 
 WORKDIR /app
 
-COPY build/libs/toyvillage.jar toyvillage.jar
+COPY gradlew gradlew.bat ./
+COPY gradle ./gradle
+COPY build.gradle settings.gradle ./
+COPY src ./src
+
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre AS runtime
+
+WORKDIR /app
+
+COPY --from=builder /app/build/libs/toyvillage.jar ./toyvillage.jar
+
+EXPOSE 8080
 
 ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "toyvillage.jar"]


### PR DESCRIPTION
### 작업 설명
- Dockerfile이 기존에는 bootJar파일을 복사만 하던 것을 한번에 bootJar까지 진행하도록 변경
### 관련 이슈
#38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 애플리케이션을 더 효율적으로 빌드하고 실행할 수 있도록 Docker 이미지 구성을 개선했습니다.
  * 실행 환경에 필요한 파일만 포함해 이미지 용량과 배포 부담을 줄였습니다.
  * 컨테이너 실행 시 production 프로파일과 8080 포트를 사용합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->